### PR TITLE
Setup Release workflow

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version = 1.0.3
+sbt.version = 1.1.0
 


### PR DESCRIPTION
Ensure the example project can be published to Bintray.

Unfortunately `bintrayRelease` task on the root of the project needs to be stubbed out as it incorrectly publishes the release despite root of the project not having any artifact to publish.

This also means the examples module will need to have the newly cut Bintray release published.

SBT is upgraded to 1.1.0 due to issues around publish settings:

https://github.com/sbt/sbt/issues/3136#issuecomment-296817619